### PR TITLE
Feat: install script .env / DISCORD_TOKEN walkthrough

### DIFF
--- a/discord_bot/install.sh
+++ b/discord_bot/install.sh
@@ -135,3 +135,36 @@ EOF
 sudo chown lunatic:lunatic "$EXISTING_CONFIG"
 sudo chmod 640 "$EXISTING_CONFIG"
 echo "config.ini written."
+
+# ── .env walkthrough ───────────────────────────────────────────────────────────
+
+echo ""
+echo "--- Discord token ---"
+
+ENV_FILE="$INSTALL_DIR/.env"
+current_token=""
+if [[ -f "$ENV_FILE" ]]; then
+    current_token="$(grep -m1 '^DISCORD_TOKEN=' "$ENV_FILE" | cut -d'=' -f2-)"
+fi
+
+if [[ -n "$current_token" ]]; then
+    token_len="${#current_token}"
+    if [[ "$token_len" -gt 8 ]]; then
+        masked="${current_token:0:4}****${current_token: -4}"
+    else
+        masked="****"
+    fi
+    echo "Current token: $masked"
+    read -rp "Discord token [keep current]: " new_token
+    DISCORD_TOKEN="${new_token:-$current_token}"
+else
+    read -rp "Discord token: " DISCORD_TOKEN
+fi
+
+sudo tee "$ENV_FILE" > /dev/null << EOF
+DISCORD_TOKEN=$DISCORD_TOKEN
+EOF
+
+sudo chown lunatic:lunatic "$ENV_FILE"
+sudo chmod 600 "$ENV_FILE"
+echo ".env written."


### PR DESCRIPTION
Implemented Task 6 of the Discord bot install script plan. This involved modifying `discord_bot/install.sh` to include a `.env` walkthrough for the `DISCORD_TOKEN`. The new logic includes:
- Checking for an existing `.env` file and extracting the current `DISCORD_TOKEN`.
- Masking all but the first and last 4 characters of the token when prompting for a new one.
- Correctly updating the `.env` file with the new or existing token.
- Setting the file ownership to `lunatic:lunatic` and permissions to `600`.
- Verified the changes with a syntax check and code review.

---
*PR created automatically by Jules for task [16423651689577038545](https://jules.google.com/task/16423651689577038545) started by @jleivo*