### PR TITLE
Docs: Update readme for installation script

### DIFF
--- a/discord_bot/readme.md
+++ b/discord_bot/readme.md
@@ -14,61 +14,21 @@ and spontaneously joins channel conversations every 5–15 messages for a few ro
 
 ## Installation
 
-### System user
+Run the installation script as a user with `sudo` privileges:
 
 ```bash
-sudo adduser --system --home /srv/discord_bot lunatic
-sudo addgroup --system lunatic
+bash discord_bot/install.sh
 ```
 
-### Dependencies
+The script will:
 
-```bash
-python3 -m venv /srv/discord_bot/.venv && source /srv/discord_bot/.venv/bin/activate
-pip install -r requirements.txt
-```
+1. Ask for the install directory (default `/srv/LunaticLeivoModel`)
+2. Create the `lunatic` system user if needed
+3. Copy bot files and set up the Python virtual environment
+4. Walk through all `config.ini` settings and the Discord token
+5. Configure rsyslog, logrotate, and the systemd service
 
-### Configuration
-
-Edit `config.ini` with your settings:
-
-| Key | Description |
-|-----|-------------|
-| `api.base_url` | OpenAI-compatible API base URL (e.g. `http://host:11434/v1` for Ollama) |
-| `api.model` | Model name to use |
-| `bot.system_prompt` | System prompt defining bot personality |
-| `bot.spontaneous_min/max` | Range for messages between spontaneous interjections |
-| `bot.active_rounds` | How many reply exchanges to stay active after interjecting |
-
-### Discord token
-
-Create `.env` next to `discord_bot.py`:
-
-```
-DISCORD_TOKEN=your_token_here
-```
-
-### Logging
-
-The bot logs to syslog via the `LOCAL0` facility. Configure rsyslog to route those entries to a dedicated file:
-
-```bash
-sudo cp dependencies/rsyslog/discord_bot.conf /etc/rsyslog.d/discord_bot.conf
-sudo systemctl restart rsyslog
-```
-
-Set up log rotation:
-
-```bash
-sudo cp dependencies/logrotate/discord_bot /etc/logrotate.d/discord_bot
-```
-
-### Systemd
-
-```bash
-sudo cp dependencies/lunatic.service /usr/lib/systemd/system/
-sudo systemctl enable --now lunatic.service
-```
+On subsequent runs it re-confirms all configuration and upgrades Python packages.
 
 ## Known Issues
 


### PR DESCRIPTION
Updated the `discord_bot/readme.md` to replace manual installation steps with instructions for the new `install.sh` script. The redundant subsections for system user, dependencies, configuration, token, logging, and systemd have been removed.

---
*PR created automatically by Jules for task [74788484445221593](https://jules.google.com/task/74788484445221593) started by @jleivo*