### PR TITLE
Add GPU Monitor with /metrics endpoint

### DIFF
--- a/manage_ollama/gpu_monitor/CHANGELOG.md
+++ b/manage_ollama/gpu_monitor/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2024-05-22
+### Added
+- Initial implementation of `gpu_monitor.py`.
+- NVIDIA GPU utilization polling via `pynvml`.
+- `/metrics` HTTP endpoint for Prometheus-style monitoring.
+- Syslog logging on Linux and rotating file logging on Windows.

--- a/manage_ollama/gpu_monitor/README.md
+++ b/manage_ollama/gpu_monitor/README.md
@@ -1,0 +1,49 @@
+# GPU Monitor
+
+A lightweight, cross-platform GPU utilization poller for Ollama proxy load monitoring.
+
+## Features
+
+- **Cross-Platform:** Supports NVIDIA GPUs on Linux and AMD GPUs on Windows.
+- **HTTP Metrics:** Provides a `/metrics` endpoint that returns GPU utilization data in JSON format.
+- **Periodic Polling:** Continuously monitors GPU activity at a configurable interval.
+
+## Usage
+
+### Install Dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### Run the Monitor
+
+```bash
+python gpu_monitor.py --port 9091
+```
+
+## API Endpoints
+
+### `GET /metrics`
+
+Returns the current GPU utilization metrics.
+
+**Response Body:**
+
+```json
+{
+  "gpu_utilization_pct": 52,
+  "gpus": [
+    {
+      "index": 0,
+      "name": "NVIDIA GeForce RTX 3080",
+      "utilization_pct": 45
+    },
+    {
+      "index": 1,
+      "name": "NVIDIA GeForce RTX 3080",
+      "utilization_pct": 52
+    }
+  ]
+}
+```

--- a/manage_ollama/gpu_monitor/gpu_monitor.py
+++ b/manage_ollama/gpu_monitor/gpu_monitor.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# 0.1.0
+"""Cross-platform GPU utilization poller for Ollama proxy load monitoring."""
+import sys
+import logging
+import logging.handlers
+import threading
+import time
+import argparse
+
+from fastapi import FastAPI, HTTPException
+import uvicorn
+
+PLATFORM_LINUX = sys.platform.startswith("linux")
+PLATFORM_WINDOWS = sys.platform == "win32"
+
+logger = logging.getLogger(__name__)
+app = FastAPI()
+
+_lock = threading.Lock()
+_metrics: dict = {}          # last successful reading
+_healthy: bool = False       # set True after first successful poll
+_poll_interval: int = 5
+_test_mode: bool = False
+
+
+def _read_nvidia() -> dict:
+    import pynvml
+    count = pynvml.nvmlDeviceGetCount()
+    gpus = []
+    for i in range(count):
+        handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+        name = pynvml.nvmlDeviceGetName(handle)
+        if isinstance(name, bytes):
+            name = name.decode()
+        util = pynvml.nvmlDeviceGetUtilizationRates(handle)
+        gpus.append({"index": i, "name": name, "utilization_pct": util.gpu})
+    max_util = max((g["utilization_pct"] for g in gpus), default=0)
+    return {"gpu_utilization_pct": max_util, "gpus": gpus}
+
+
+def _read_amd() -> dict:
+    import amdsmi  # noqa: F401 — Windows only, installed as system package
+    devices = amdsmi.amdsmi_get_processor_handles()
+    gpus = []
+    for i, device in enumerate(devices):
+        activity = amdsmi.amdsmi_get_gpu_activity(device)
+        asic = amdsmi.amdsmi_get_gpu_asic_info(device)
+        name = asic.get("market_name", f"AMD GPU {i}")
+        util = activity.get("gfx_activity", 0)
+        gpus.append({"index": i, "name": name, "utilization_pct": util})
+    max_util = max((g["utilization_pct"] for g in gpus), default=0)
+    return {"gpu_utilization_pct": max_util, "gpus": gpus}
+
+
+def _poll_loop(interval: int) -> None:
+    global _metrics, _healthy
+    while True:
+        try:
+            data = _read_nvidia() if PLATFORM_LINUX else _read_amd()
+            with _lock:
+                _metrics = data
+                _healthy = True
+            logger.info("GPU utilization: %d%%", data["gpu_utilization_pct"])
+        except Exception as exc:
+            logger.warning("Failed to read GPU metrics: %s", exc)
+            with _lock:
+                _healthy = False
+        time.sleep(interval)
+
+
+@app.get("/metrics")
+def get_metrics():
+    with _lock:
+        if not _healthy:
+            raise HTTPException(status_code=503, detail="GPU metrics unavailable")
+        return dict(_metrics)
+
+
+def setup_logging() -> None:
+    if PLATFORM_LINUX:
+        handler = logging.handlers.SysLogHandler(address="/dev/log")
+        fmt = "gpu_monitor: %(levelname)s %(message)s"
+    else:
+        import os
+        log_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "gpu_monitor.log")
+        handler = logging.handlers.TimedRotatingFileHandler(
+            log_path, when="midnight", backupCount=7
+        )
+        fmt = "%(asctime)s %(levelname)s %(message)s"
+    logging.basicConfig(level=logging.INFO, handlers=[handler], format=fmt)
+
+
+def start_poll_thread(interval: int) -> None:
+    if _test_mode:
+        # In test mode, we want to poll once synchronously to populate _metrics
+        global _metrics, _healthy
+        try:
+            data = _read_nvidia() if PLATFORM_LINUX else _read_amd()
+            _metrics = data
+            _healthy = True
+        except Exception as exc:
+            logger.warning("Failed to read GPU metrics in test mode: %s", exc)
+            _healthy = False
+        return
+
+    t = threading.Thread(target=_poll_loop, args=(interval,), daemon=True)
+    t.start()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="GPU utilization HTTP monitor")
+    parser.add_argument("--port", type=int, default=9091)
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--poll-interval", type=int, default=5, dest="poll_interval")
+    args = parser.parse_args()
+
+    setup_logging()
+
+    if PLATFORM_LINUX:
+        import pynvml
+        pynvml.nvmlInit()
+        logger.info("Initialised NVIDIA GPU monitoring via pynvml.")
+    elif PLATFORM_WINDOWS:
+        import amdsmi
+        amdsmi.amdsmi_init()
+        logger.info("Initialised AMD GPU monitoring via amdsmi.")
+    else:
+        logger.error("Unsupported platform: %s", sys.platform)
+        sys.exit(1)
+
+    start_poll_thread(args.poll_interval)
+    uvicorn.run(app, host=args.host, port=args.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/manage_ollama/gpu_monitor/tests/test_gpu_monitor.py
+++ b/manage_ollama/gpu_monitor/tests/test_gpu_monitor.py
@@ -1,0 +1,102 @@
+import sys
+import pytest
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Helpers to build a fake pynvml module
+# ---------------------------------------------------------------------------
+
+def _make_pynvml_mock(gpu_utils):
+    """Build a pynvml mock returning given per-GPU utilization percentages."""
+    mock = MagicMock()
+    mock.nvmlDeviceGetCount.return_value = len(gpu_utils)
+    handles = [MagicMock() for _ in gpu_utils]
+    mock.nvmlDeviceGetHandleByIndex.side_effect = lambda i: handles[i]
+    mock.nvmlDeviceGetName.side_effect = lambda h: f"NVIDIA GPU {handles.index(h)}"
+    util_rates = [MagicMock(gpu=u) for u in gpu_utils]
+    mock.nvmlDeviceGetUtilizationRates.side_effect = lambda h: util_rates[handles.index(h)]
+    return mock
+
+
+@pytest.fixture()
+def nvidia_client(monkeypatch):
+    """TestClient with NVIDIA platform mocked."""
+    fake_nvml = _make_pynvml_mock([45, 52])
+    monkeypatch.setattr("sys.platform", "linux")
+    with patch.dict(sys.modules, {"pynvml": fake_nvml}):
+        # Re-import to pick up patched modules
+        import importlib
+        import manage_ollama.gpu_monitor.gpu_monitor as gm
+        importlib.reload(gm)
+        gm._test_mode = True
+        gm.start_poll_thread(5)
+        from fastapi.testclient import TestClient
+        yield TestClient(gm.app), gm
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_metrics_returns_200(nvidia_client):
+    client, _ = nvidia_client
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+
+
+def test_metrics_has_required_fields(nvidia_client):
+    client, _ = nvidia_client
+    data = client.get("/metrics").json()
+    assert "gpu_utilization_pct" in data
+    assert "gpus" in data
+    assert isinstance(data["gpu_utilization_pct"], (int, float))
+    assert isinstance(data["gpus"], list)
+
+
+def test_metrics_gpu_utilization_is_max_across_gpus(nvidia_client):
+    """Top-level value must be the MAX across all GPUs (45 and 52 → 52)."""
+    client, _ = nvidia_client
+    data = client.get("/metrics").json()
+    assert data["gpu_utilization_pct"] == 52
+
+
+def test_metrics_gpus_list_has_correct_shape(nvidia_client):
+    client, _ = nvidia_client
+    data = client.get("/metrics").json()
+    assert len(data["gpus"]) == 2
+    for gpu in data["gpus"]:
+        assert "index" in gpu
+        assert "name" in gpu
+        assert "utilization_pct" in gpu
+
+
+def test_metrics_single_gpu(monkeypatch):
+    fake_nvml = _make_pynvml_mock([73])
+    monkeypatch.setattr("sys.platform", "linux")
+    with patch.dict(sys.modules, {"pynvml": fake_nvml}):
+        import importlib
+        import manage_ollama.gpu_monitor.gpu_monitor as gm
+        importlib.reload(gm)
+        gm._test_mode = True
+        gm.start_poll_thread(5)
+        from fastapi.testclient import TestClient
+        resp = TestClient(gm.app).get("/metrics")
+        data = resp.json()
+        assert data["gpu_utilization_pct"] == 73
+        assert len(data["gpus"]) == 1
+
+
+def test_metrics_gpu_library_error_returns_503(monkeypatch):
+    """If pynvml raises during read, /metrics must return 503."""
+    fake_nvml = MagicMock()
+    fake_nvml.nvmlDeviceGetCount.side_effect = RuntimeError("nvml error")
+    monkeypatch.setattr("sys.platform", "linux")
+    with patch.dict(sys.modules, {"pynvml": fake_nvml}):
+        import importlib
+        import manage_ollama.gpu_monitor.gpu_monitor as gm
+        importlib.reload(gm)
+        gm._test_mode = True
+        gm.start_poll_thread(5)
+        from fastapi.testclient import TestClient
+        resp = TestClient(gm.app).get("/metrics")
+        assert resp.status_code == 503


### PR DESCRIPTION
Implemented a cross-platform GPU utilization monitor using FastAPI.
Includes background polling, /metrics endpoint, and support for NVIDIA (Linux) and AMD (Windows).
Added tests, README, and CHANGELOG as per repository conventions.

---
*PR created automatically by Jules for task [17684864392285221270](https://jules.google.com/task/17684864392285221270) started by @jleivo*