### PR TITLE
Add deployment files for gpu_monitor

### DIFF
--- a/manage_ollama/dependencies/gpu_monitor/gpu_monitor.service
+++ b/manage_ollama/dependencies/gpu_monitor/gpu_monitor.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=GPU utilization monitor for Ollama proxy
+After=network.target
+
+[Service]
+Type=simple
+User=gpu_monitor
+WorkingDirectory=/opt/gpu_monitor
+ExecStart=/opt/gpu_monitor/.venv/bin/python /opt/gpu_monitor/gpu_monitor.py
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/manage_ollama/dependencies/gpu_monitor/install_linux.sh
+++ b/manage_ollama/dependencies/gpu_monitor/install_linux.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+INSTALL_DIR="${1:-/opt/gpu_monitor}"
+
+echo "Installing gpu_monitor to $INSTALL_DIR..."
+
+# Create system user if not exists
+id -u gpu_monitor &>/dev/null || useradd --system --no-create-home --shell /usr/sbin/nologin gpu_monitor
+
+# Create install directory
+mkdir -p "$INSTALL_DIR"
+cp "$(dirname "$0")/../../gpu_monitor/gpu_monitor.py" "$INSTALL_DIR/"
+cp "$(dirname "$0")/../../gpu_monitor/requirements.txt" "$INSTALL_DIR/"
+
+# Create venv and install deps
+python3 -m venv "$INSTALL_DIR/.venv"
+"$INSTALL_DIR/.venv/bin/pip" install --upgrade pip -q
+"$INSTALL_DIR/.venv/bin/pip" install -r "$INSTALL_DIR/requirements.txt" -q
+
+chown -R gpu_monitor:gpu_monitor "$INSTALL_DIR"
+
+# rsyslog
+cp "$(dirname "$0")/rsyslog_gpu_monitor.conf" /etc/rsyslog.d/gpu_monitor.conf
+systemctl restart rsyslog
+
+# logrotate
+cp "$(dirname "$0")/logrotate_gpu_monitor.conf" /etc/logrotate.d/gpu_monitor
+
+# systemd service (substitute install dir)
+sed "s|/opt/gpu_monitor|$INSTALL_DIR|g" "$(dirname "$0")/gpu_monitor.service" \
+    > /etc/systemd/system/gpu_monitor.service
+systemctl daemon-reload
+systemctl enable --now gpu_monitor
+
+echo "gpu_monitor installed and started. Check: systemctl status gpu_monitor"

--- a/manage_ollama/dependencies/gpu_monitor/install_windows.ps1
+++ b/manage_ollama/dependencies/gpu_monitor/install_windows.ps1
@@ -1,0 +1,25 @@
+#Requires -RunAsAdministrator
+param(
+    [string]$InstallDir = "C:\opt\gpu_monitor",
+    [string]$NssmPath = "nssm.exe"
+)
+
+Write-Host "Installing gpu_monitor to $InstallDir..."
+
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+Copy-Item "$PSScriptRoot\..\..\gpu_monitor\gpu_monitor.py" $InstallDir
+Copy-Item "$PSScriptRoot\..\..\gpu_monitor\requirements.txt" $InstallDir
+
+# Create venv and install deps
+python -m venv "$InstallDir\.venv"
+& "$InstallDir\.venv\Scripts\pip.exe" install --upgrade pip -q
+& "$InstallDir\.venv\Scripts\pip.exe" install -r "$InstallDir\requirements.txt" -q
+
+# Register Windows service via NSSM
+& $NssmPath install gpu_monitor "$InstallDir\.venv\Scripts\python.exe"
+& $NssmPath set gpu_monitor AppParameters "$InstallDir\gpu_monitor.py"
+& $NssmPath set gpu_monitor AppDirectory $InstallDir
+& $NssmPath set gpu_monitor Start SERVICE_AUTO_START
+& $NssmPath start gpu_monitor
+
+Write-Host "gpu_monitor service installed and started."

--- a/manage_ollama/dependencies/gpu_monitor/logrotate_gpu_monitor.conf
+++ b/manage_ollama/dependencies/gpu_monitor/logrotate_gpu_monitor.conf
@@ -1,0 +1,10 @@
+/var/log/gpu_monitor.log {
+    daily
+    rotate 7
+    compress
+    missingok
+    notifempty
+    postrotate
+        systemctl restart rsyslog > /dev/null 2>&1 || true
+    endscript
+}

--- a/manage_ollama/dependencies/gpu_monitor/rsyslog_gpu_monitor.conf
+++ b/manage_ollama/dependencies/gpu_monitor/rsyslog_gpu_monitor.conf
@@ -1,0 +1,2 @@
+if $programname == 'gpu_monitor' then /var/log/gpu_monitor.log
+& stop


### PR DESCRIPTION
I have created the deployment and installation files for the `gpu_monitor` component as requested. 

Files created:
- `manage_ollama/dependencies/gpu_monitor/gpu_monitor.service`
- `manage_ollama/dependencies/gpu_monitor/rsyslog_gpu_monitor.conf`
- `manage_ollama/dependencies/gpu_monitor/logrotate_gpu_monitor.conf`
- `manage_ollama/dependencies/gpu_monitor/install_linux.sh` (with execute permissions)
- `manage_ollama/dependencies/gpu_monitor/install_windows.ps1`

I have also verified the contents of these files and ensured that no binary artifacts are included in the commit. Pre-existing test failures were investigated and found to be unrelated to these new files.

---
*PR created automatically by Jules for task [10062824162085457599](https://jules.google.com/task/10062824162085457599) started by @jleivo*